### PR TITLE
Fix bug for multiple empty slugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ function BananaSlug () {
   var self = this
   if (!(self instanceof BananaSlug)) return new BananaSlug()
 
-  self.slugs = []
+  self.reset()
 }
 
 /**
@@ -15,22 +15,21 @@ function BananaSlug () {
 BananaSlug.prototype.slug = function (value) {
   var self = this
   var slug = slugger(value)
-  if (self.slugs.some(slugExists)) {
-    var suffix = '-' + self.slugs.filter(slugMatches).length
-    slug = slug + suffix
+  var occurrences = self.occurrences[slug]
+
+  if (self.occurrences.hasOwnProperty(slug)) {
+    occurrences++
+  } else {
+    occurrences = 0
   }
 
-  self.slugs.push(slug)
+  self.occurrences[slug] = occurrences
+
+  if (occurrences) {
+    slug = slug + '-' + occurrences
+  }
+
   return slug
-
-  function slugMatches (s) {
-    var slugMatch = new RegExp(slug + '(-[0-9])*$')
-    return slugMatch.test(s)
-  }
-
-  function slugExists (s) {
-    return s === slug
-  }
 }
 
 /**
@@ -38,7 +37,7 @@ BananaSlug.prototype.slug = function (value) {
  * @return void
  */
 BananaSlug.prototype.reset = function () {
-  this.slugs = []
+  this.occurrences = {}
 }
 
 var whitespace = /\s/g

--- a/test/index.js
+++ b/test/index.js
@@ -45,6 +45,31 @@ var testCases = [
     slug: 'exchangebind_headersexchange-routing--bindcallback'
   },
   {
+    mesg: 'empty',
+    text: '',
+    slug: ''
+  },
+  {
+    mesg: 'a space',
+    text: ' ',
+    slug: '-1'
+  },
+  {
+    mesg: 'initial space',
+    text: ' initial space',
+    slug: 'initial-space'
+  },
+  {
+    mesg: 'final space',
+    text: 'final space ',
+    slug: 'final-space'
+  },
+  {
+    mesg: 'deals with prototype properties',
+    text: 'length',
+    slug: 'length'
+  },
+  {
     mesg: 'deals with duplicates correctly',
     text: 'duplicate',
     slug: 'duplicate'


### PR DESCRIPTION
Previously, when more than one empty slugs were cached, instead
of using the duplicate count of those empty slugs, the count of *all*
slugs was used as a suffix for future empty slugs

For example:

```js
slug('foo') // 'foo'
slug('') // ''
slug('bar') // 'bar'
slug(' ') // '-3'
```

Now yields:

```js
slug('foo') // 'foo'
slug('') // ''
slug('bar') // 'bar'
slug(' ') // '-1'
```

P.S. an example of this can be seen in [marky-markdown’s usage](https://github.com/npm/marky-markdown/blob/b57723ad0bea30a8f66d9c3811eb5169052b4f31/lib/headings.js#L9), in [this test case](https://www.npmjs.com/package/gh-and-npm-slug-generation#-9).

P.P.S. I started out thinking this would be a small change, but in the process came up with a slightly bigger algorithmic refactor, I see no downsides in using this system (an object), as it doesn’t require regexes, do you?