### PR TITLE
Convert emoji to short names in generated slugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 module.exports = BananaSlug
 
+var wemoji = require('wemoji')
+
 function BananaSlug () {
   var self = this
   if (!(self instanceof BananaSlug)) return new BananaSlug()
@@ -42,6 +44,21 @@ BananaSlug.prototype.reset = function () {
 
 var whitespace = /\s/g
 
+function convertEmoji (string) {
+  for (var idx = 0; idx < string.length; idx++) {
+    // inspect two characters at a time because indexing characters in JavaScript
+    // strings like this ends up splitting the unicode code points up
+    // (see https://mathiasbynens.be/notes/javascript-unicode)
+    var emoji = wemoji.unicode[string[idx] + string[idx + 1]]
+    if (emoji) {
+      string = string.substring(0, idx) + emoji.name + string.substring(idx + 1)
+      idx += emoji.name.length
+    }
+  }
+
+  return string
+}
+
 function slugger (string) {
   var allowedCharacters = 'A-Za-z0-9_ -'
   var re = new RegExp('[^' + allowedCharacters + ']', 'g')
@@ -51,6 +68,6 @@ function slugger (string) {
 
   if (typeof string !== 'string') return ''
   if (!maintainCase) string = string.toLowerCase()
-  result = string.trim().replace(re, '').replace(whitespace, replacement)
+  result = convertEmoji(string.trim()).replace(re, '').replace(whitespace, replacement)
   return result
 }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   },
   "scripts": {
     "test": "standard && tape test/*.js | tap-spec"
+  },
+  "dependencies": {
+    "wemoji": "^1.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -83,5 +83,20 @@ var testCases = [
     mesg: 'deals with duplicates correctly-2',
     text: 'duplicate',
     slug: 'duplicate-2'
+  },
+  {
+    mesg: 'handles emoji',
+    text: 'emoji 👌 test',
+    slug: 'emoji-ok_hand-test'
+  },
+  {
+    mesg: 'handles emojis without space between',
+    text: '👌🐥',
+    slug: 'ok_handhatched_chick'
+  },
+  {
+    mesg: 'handles emojis with space between',
+    text: 'emoji 👌 🐥',
+    slug: 'emoji-ok_hand-hatched_chick'
   }
 ]


### PR DESCRIPTION
Hello, our project [marky-markdown](https://www.npmjs.com/package/marky-markdown) generates heading slugs with github-slugger here, and we had an issue come up where it turns out that GitHub converts any emoji characters in headings to their shortcode names when generating slugs, whereas we just skip them because they're not in the `allowedCharacters`. If you'd like to see an example, the issue is [marky-markdown#128](https://github.com/npm/marky-markdown/issues/128).

What I've done here is pull in the [wemoji](https://www.npmjs.com/package/wemoji) package to use as a data source for the short names, then use it as a catalog to convert emoji characters to their short names in place before running the string through the `allowedCharacters` filter. I've also included three tests based on the ones from our issue.

It occurs to me that I should probably explicitly acknowledge that this would require a first-digit version bump per semver, but I guess that can't be helped, given the nature of what we're doing.

Thanks for considering this, and thanks for the github-slugger module!