### PR TITLE
Fix dependency emoji-regex semver spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/Flet/github-slugger/issues"
   },
   "dependencies": {
-    "emoji-regex": "^>=6.0.0 <=6.1.1"
+    "emoji-regex": ">=6.0.0 <=6.1.1"
   },
   "devDependencies": {
     "standard": "*",


### PR DESCRIPTION
I discovered npm 5 was [failing to install emoji-regex](https://github.com/npm/npm/issues/16744); turns out it's because the semver string in package.json [isn't technically valid](https://github.com/npm/npm/issues/16744#issuecomment-304493370). The npm folks [say](https://github.com/npm/npm/issues/16744#issuecomment-304495283) they're interested in fixing this because npm 4 handled it OK, but perhaps it's worth fixing here as well.

The change here makes it work in both npm 4 & 5.