### PR TITLE
Fix semver range for `emoji-regex`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/Flet/github-slugger/issues"
   },
   "dependencies": {
-    "emoji-regex": "^>=6.0.0 <=6.1.1"
+    "emoji-regex": ">=6.0.0 <=6.1.1"
   },
   "devDependencies": {
     "standard": "*",


### PR DESCRIPTION
Remove a redundant caret character to make the versions range
syntactically valid. It fixes installation issues with npm 5.