### PR TITLE
Add "files" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "bugs": {
     "url": "https://github.com/Flet/github-slugger/issues"
   },
+  "files": [
+    "index.js"
+  ],
   "dependencies": {
     "emoji-regex": ">=6.0.0 <=6.1.1"
   },


### PR DESCRIPTION
This will avoid publishing unnecessary files to npm.

Read more about this feature in [the npm docs](https://docs.npmjs.com/files/package.json#files)