### PR TITLE
Fix accessing or overwriting Object.prototype methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ BananaSlug.prototype.slug = function (value, maintainCase) {
   var slug = slugger(value, maintainCase)
   var occurrences = self.occurrences[slug]
 
-  if (self.occurrences.hasOwnProperty(slug)) {
+  if (Object.hasOwnProperty.call(self.occurrences, slug)) {
     occurrences++
   } else {
     occurrences = 0
@@ -41,7 +41,7 @@ BananaSlug.prototype.slug = function (value, maintainCase) {
  * @return void
  */
 BananaSlug.prototype.reset = function () {
-  this.occurrences = {}
+  this.occurrences = Object.create(null)
 }
 
 var whitespace = /\s/g

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,10 @@ test('simple stuff', function (t) {
   t.equals('fooCamelCase', slugger.slug('fooCamelCase', true))
   t.equals('foocamelcase', slugger.slug('fooCamelCase'))
 
+  slugger.reset()
+  t.equals('__proto__', slugger.slug('__proto__'))
+  t.equals('__proto__-1', slugger.slug('__proto__'))
+
   t.end()
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,8 @@ test('simple stuff', function (t) {
   slugger.reset()
   t.equals('__proto__', slugger.slug('__proto__'))
   t.equals('__proto__-1', slugger.slug('__proto__'))
+  t.equals('hasOwnProperty', slugger.slug('hasOwnProperty', true))
+  t.equals('foo', slugger.slug('foo'))
 
   t.end()
 })


### PR DESCRIPTION
There are methods (including getters / setters) defined on `Object.prototype`, and when an input to slugger matches one of them, the result may be incorrect.
In particular, `hasOwnProperty` and `__proto__` are the examples that actually cause troubles.

Initializing `occurrences` object  with `Object.create(null)` and checking property existence with `Object.prototype.hasOwnProperty.call` will fix it.
