### PR TITLE
Replace apostrophe with empty string (like github)

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = BananaSlug
 
 var own = Object.hasOwnProperty
 var whitespace = /\s/g
-var specials = /[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,./:;<=>?@[\]^`{|}~]/g
+var specials = /[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,./:;<=>?@[\]^`{|}~’]/g
 
 function BananaSlug () {
   var self = this

--- a/test/6-characters.md
+++ b/test/6-characters.md
@@ -13,3 +13,5 @@
 #  initial space
 
 # final space 
+
+# heading with apostrophe’s

--- a/test/index.js
+++ b/test/index.js
@@ -102,6 +102,12 @@ var testCases = [
     text: 'final space ',
     slug: 'final-space'
   },
+  // Note: Apostrophe in heading is trimmed off in markdown
+  {
+    mesg: 'apostrophe’s should be trimmed',
+    text: 'apostrophe’s should be trimmed',
+    slug: 'apostrophes-should-be-trimmed'
+  },
   // See `7-duplicates.md`
   {
     mesg: 'deals with duplicates correctly',


### PR DESCRIPTION
@Flet @wooorm 
Github treats apostrophe as empty string. Hence, slugger should do the same. We have a requirement were we are consuming `github-slugger` and lack of this behaviour is causing issues. Hence, we would greatly appreciate if you could review and merge this PR soon. Thanks! 🙃
