### PR TITLE
fix: strip HTML entities like &gt;

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = BananaSlug
 var own = Object.hasOwnProperty
 var whitespace = /\s/g
 var specials = /[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,./:;<=>?@[\]^`{|}~’]/g
+var entities = /&[^;]+;/g
 
 function BananaSlug () {
   var self = this
@@ -48,6 +49,7 @@ function slugger (string, maintainCase) {
   if (!maintainCase) string = string.toLowerCase()
 
   return string.trim()
+    .replace(entities, '')
     .replace(specials, '')
     .replace(emoji(), '')
     .replace(whitespace, '-')

--- a/test/index.js
+++ b/test/index.js
@@ -205,5 +205,10 @@ var testCases = [
     mesg: 'emoji-slug-example-4',
     text: ':ok_hand: :hatched_chick: Two in a row',
     slug: 'ok_hand-hatched_chick-two-in-a-row'
+  },
+  {
+    mesg: 'html-entities',
+    text: '&lt;div&gt; elements',
+    slug: 'div-elements'
   }
 ]


### PR DESCRIPTION
I discovered in my repo https://github.com/vscodeshift/material-ui-snippets that HTML entities like `&gt;` get stripped out of slugs.  Right now in this and other libs, `&lt;div&gt;` gets converted to `ltdivgt`, but the actual GitHub slug is just `div`.