### PR TITLE
feat(static): expose slug function

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ slugger.slug('foo')
 ```
 Check `test/index.js` for more examples.
 
+If you need, you can also use the underlying implementation which does not keep
+track of the previously slugged strings (not recommended):
+
+```js
+var slugger = require('github-slugger').slug;
+
+slug('foo bar baz')
+// returns 'foo-bar-baz'
+
+slug('foo bar baz')
+// returns the same slug 'foo-bar-baz' because it does not keep track
+```
+
 ## Contributing
 
 Contributions welcome! Please read the [contributing guidelines](CONTRIBUTING.md) first.

--- a/index.js
+++ b/index.js
@@ -52,3 +52,5 @@ function slugger (string, maintainCase) {
     .replace(emoji(), '')
     .replace(whitespace, '-')
 }
+
+BananaSlug.slug = slugger

--- a/test/test-static.js
+++ b/test/test-static.js
@@ -4,9 +4,6 @@ var GithubSlugger = require('../')
 test('static method - simple stuff', function (t) {
   var slug = GithubSlugger.slug
 
-  t.equals(slug('foo'), 'foo', 'should work without new')
-  t.equals(slug(1), '', 'should return empty string for non-strings')
-
   // See `1-basic-usage.md`
   t.equals(slug('foo'), 'foo')
   t.equals(slug('foo bar'), 'foo-bar')
@@ -14,154 +11,19 @@ test('static method - simple stuff', function (t) {
 
   // See `2-camel-case.md`
   t.equals(slug('foo'), 'foo')
+
   // Note: GH doesn’t support `maintaincase`, so the actual values are commented below.
   t.equals(slug('fooCamelCase', true), 'fooCamelCase') // foocamelcase
-  t.equals(slug('fooCamelCase'), 'foocamelcase') // foocamelcase-1
-
-  // See `3-prototype.md`
-  t.equals(slug('__proto__'), '__proto__')
-  t.equals(slug('__proto__'), '__proto__')
-  t.equals(slug('hasOwnProperty', true), 'hasOwnProperty') // hasownproperty
-  t.equals(slug('foo'), 'foo')
+  t.equals(slug('fooCamelCase'), 'foocamelcase') // foocamelcase
 
   t.end()
 })
 
-test('static method - github test cases', function (t) {
+test('static method - yielding empty strings', function (t) {
   var slug = GithubSlugger.slug
 
-  testCases.forEach(function (test) {
-    t.equals(slug(test.text), test.slug, test.mesg)
-  })
+  t.equals(slug(1), '', 'should return empty string for non-strings')
+  t.equals(slug(' '), '')
 
   t.end()
 })
-
-var testCases = [
-  // See `6-characters.md`
-  {
-    mesg: 'allows a dash',
-    text: 'heading with a - dash',
-    slug: 'heading-with-a---dash'
-  },
-  {
-    mesg: 'allows underscores',
-    text: 'heading with an _ underscore',
-    slug: 'heading-with-an-_-underscore'
-  },
-  {
-    mesg: 'filters periods',
-    text: 'heading with a period.txt',
-    slug: 'heading-with-a-periodtxt'
-  },
-  {
-    mesg: 'allows two spaces even after filtering',
-    text: 'exchange.bind_headers(exchange, routing [, bindCallback])',
-    slug: 'exchangebind_headersexchange-routing--bindcallback'
-  },
-  // Note: GH doesn’t create slugs for empty headings.
-  {
-    mesg: 'empty',
-    text: '',
-    slug: ''
-  },
-  // Note: white-space in headings is trimmed off in markdown.
-  {
-    mesg: 'initial space',
-    text: ' initial space',
-    slug: 'initial-space'
-  },
-  {
-    mesg: 'final space',
-    text: 'final space ',
-    slug: 'final-space'
-  },
-  // Note: Apostrophe in heading is trimmed off in markdown
-  {
-    mesg: 'apostrophe’s should be trimmed',
-    text: 'apostrophe’s should be trimmed',
-    slug: 'apostrophes-should-be-trimmed'
-  },
-  // See `8-non-ascii.md`
-  {
-    mesg: 'gh-and-npm-slug-generation-1',
-    text: 'I ♥ unicode',
-    slug: 'i--unicode'
-  },
-  {
-    mesg: 'gh-and-npm-slug-generation-2',
-    text: 'Dash-dash',
-    slug: 'dash-dash'
-  },
-  {
-    mesg: 'gh-and-npm-slug-generation-3',
-    text: 'en–dash!',
-    slug: 'endash'
-  },
-  {
-    mesg: 'gh-and-npm-slug-generation-4',
-    text: 'em–dash',
-    slug: 'emdash'
-  },
-  {
-    mesg: 'gh-and-npm-slug-generation-5',
-    text: '😄 unicode emoji',
-    slug: '-unicode-emoji'
-  },
-  {
-    mesg: 'gh-and-npm-slug-generation-6',
-    text: '😄-😄 unicode emoji',
-    slug: '--unicode-emoji'
-  },
-  {
-    mesg: 'gh-and-npm-slug-generation-7',
-    text: '😄_😄 unicode emoji',
-    slug: '_-unicode-emoji'
-  },
-  {
-    mesg: 'gh-and-npm-slug-generation-8',
-    text: '😄 - an emoji',
-    slug: '---an-emoji'
-  },
-  {
-    mesg: 'gh-and-npm-slug-generation-9',
-    text: ':smile: - a gemoji',
-    slug: 'smile---a-gemoji'
-  },
-  {
-    mesg: 'deals with non-latin chars',
-    text: 'Привет',
-    slug: 'привет'
-  },
-  {
-    mesg: 'Cyrillic',
-    text: 'Профили пользователей',
-    slug: 'профили-пользователей'
-  },
-  {
-    mesg: 'More non-latin',
-    text: 'Привет non-latin 你好',
-    slug: 'привет-non-latin-你好'
-  },
-  // See `9-emoji.md`
-  {
-    mesg: 'emoji-slug-example-1',
-    text: ':ok: No underscore',
-    slug: 'ok-no-underscore'
-  },
-  {
-    mesg: 'emoji-slug-example-2',
-    text: ':ok_hand: Single',
-    slug: 'ok_hand-single'
-  },
-  {
-    mesg: 'emoji-slug-example-3',
-    text: ':ok_hand::hatched_chick: Two in a row with no spaces',
-    slug: 'ok_handhatched_chick-two-in-a-row-with-no-spaces'
-  },
-  {
-    mesg: 'emoji-slug-example-4',
-    text: ':ok_hand: :hatched_chick: Two in a row',
-    slug: 'ok_hand-hatched_chick-two-in-a-row'
-  }
-]

--- a/test/test-static.js
+++ b/test/test-static.js
@@ -1,60 +1,37 @@
 var test = require('tape')
 var GithubSlugger = require('../')
 
-require('./test-static')
+test('static method - simple stuff', function (t) {
+  var slug = GithubSlugger.slug
 
-test('simple stuff', function (t) {
-  var slugger = new GithubSlugger()
-
-  t.equals(GithubSlugger().slug('foo'), 'foo', 'should work without new')
-  t.equals(slugger.slug(1), '', 'should return empty string for non-strings')
+  t.equals(slug('foo'), 'foo', 'should work without new')
+  t.equals(slug(1), '', 'should return empty string for non-strings')
 
   // See `1-basic-usage.md`
-  t.equals(slugger.slug('foo'), 'foo')
-  t.equals(slugger.slug('foo bar'), 'foo-bar')
-  t.equals(slugger.slug('foo'), 'foo-1')
+  t.equals(slug('foo'), 'foo')
+  t.equals(slug('foo bar'), 'foo-bar')
+  t.equals(slug('foo'), 'foo') // idem potent
 
   // See `2-camel-case.md`
-  slugger.reset()
-  t.equals(slugger.slug('foo'), 'foo')
+  t.equals(slug('foo'), 'foo')
   // Note: GH doesn’t support `maintaincase`, so the actual values are commented below.
-  t.equals(slugger.slug('fooCamelCase', true), 'fooCamelCase') // foocamelcase
-  t.equals(slugger.slug('fooCamelCase'), 'foocamelcase') // foocamelcase-1
+  t.equals(slug('fooCamelCase', true), 'fooCamelCase') // foocamelcase
+  t.equals(slug('fooCamelCase'), 'foocamelcase') // foocamelcase-1
 
   // See `3-prototype.md`
-  slugger.reset()
-  t.equals(slugger.slug('__proto__'), '__proto__')
-  t.equals(slugger.slug('__proto__'), '__proto__-1')
-  t.equals(slugger.slug('hasOwnProperty', true), 'hasOwnProperty') // hasownproperty
-  t.equals(slugger.slug('foo'), 'foo')
+  t.equals(slug('__proto__'), '__proto__')
+  t.equals(slug('__proto__'), '__proto__')
+  t.equals(slug('hasOwnProperty', true), 'hasOwnProperty') // hasownproperty
+  t.equals(slug('foo'), 'foo')
 
   t.end()
 })
 
-test('matching slugs', function (t) {
-  var slugger = new GithubSlugger()
-
-  // See `4-matching-slugs-basic.md`
-  t.equals(slugger.slug('foo'), 'foo')
-  t.equals(slugger.slug('foo'), 'foo-1')
-  t.equals(slugger.slug('foo 1'), 'foo-1-1')
-  t.equals(slugger.slug('foo-1'), 'foo-1-2')
-  t.equals(slugger.slug('foo'), 'foo-2')
-
-  // See `5-matching-slugs-again.md`
-  slugger.reset()
-  t.equals(slugger.slug('foo-1'), 'foo-1')
-  t.equals(slugger.slug('foo'), 'foo')
-  t.equals(slugger.slug('foo'), 'foo-2')
-
-  t.end()
-})
-
-test('github test cases', function (t) {
-  var slugger = new GithubSlugger()
+test('static method - github test cases', function (t) {
+  var slug = GithubSlugger.slug
 
   testCases.forEach(function (test) {
-    t.equals(slugger.slug(test.text), test.slug, test.mesg)
+    t.equals(slug(test.text), test.slug, test.mesg)
   })
 
   t.end()
@@ -88,11 +65,6 @@ var testCases = [
     text: '',
     slug: ''
   },
-  {
-    mesg: 'a space',
-    text: ' ',
-    slug: '-1'
-  },
   // Note: white-space in headings is trimmed off in markdown.
   {
     mesg: 'initial space',
@@ -109,22 +81,6 @@ var testCases = [
     mesg: 'apostrophe’s should be trimmed',
     text: 'apostrophe’s should be trimmed',
     slug: 'apostrophes-should-be-trimmed'
-  },
-  // See `7-duplicates.md`
-  {
-    mesg: 'deals with duplicates correctly',
-    text: 'duplicates',
-    slug: 'duplicates'
-  },
-  {
-    mesg: 'deals with duplicates correctly-1',
-    text: 'duplicates',
-    slug: 'duplicates-1'
-  },
-  {
-    mesg: 'deals with duplicates correctly-2',
-    text: 'duplicates',
-    slug: 'duplicates-2'
   },
   // See `8-non-ascii.md`
   {


### PR DESCRIPTION
This change exposes the underlying implementation.

For the function naming, I've picked `slug` rather than `slugger` for consistency with the API:

```js
new GithubSlugger().slug(string);
GithubSlugger.slug(string);
```

I've copied the tests from the test suite for "simplicity" because I had to make some small changes in them (mainly the duplication of strings).

Drawback:
 - it is not possible to use the function on `' '` because it relies on the state.

Besides that, everything works as expected. Please let me know if there is anything I can do to improve this PR.

Fix #28 