### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you need, you can also use the underlying implementation which does not keep
 track of the previously slugged strings (not recommended):
 
 ```js
-var slugger = require('github-slugger').slug;
+var slug = require('github-slugger').slug;
 
 slug('foo bar baz')
 // returns 'foo-bar-baz'


### PR DESCRIPTION
Fixes the following example:

```js
var slugger = require('github-slugger').slug;

slug('foo bar baz')
// returns 'foo-bar-baz'

slug('foo bar baz')
// returns the same slug 'foo-bar-baz' because it does not keep track
```

I assumed `slugger` was a typo.

An alternative is `slugger.slug()` instead of `slug()`, but that might imply that it must be a method call, which isn't the case?