### PR TITLE
Wrench emojis is removed

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,14 @@ test('static method', function (t) {
   t.end()
 })
 
+test('emojis', function (t) {
+  const slugger = new GithubSlugger()
+
+  t.equals(slugger.slug('📝'), '', 'should remove emoji')
+  t.equals(slugger.slug('🔨'), '', 'should remove this emoji too')
+  t.end()
+})
+
 test('fixtures', function (t) {
   const slugger = new GithubSlugger()
 


### PR DESCRIPTION
Hey, thanks for making this library. 

While I was using [rehype-slug](https://github.com/rehypejs/rehype-slug) I realized that this emoji 🛠️ gets converted to something like `%EF%B8%8F`. According to the readme, I'd expect it to be converted to an empty string ``. https://emojipedia.org/hammer-and-wrench/

I've added a test to reproduce it. 

Can I get some pointers or help to modify the regex to consider this scenario?